### PR TITLE
Update README to reflect EC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Vagrant
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -30,5 +30,3 @@ In case you already have a VM created and just wants to execute the Ansible play
 
 ## Todo:
 * Add gluster volume
-* add EC Storage policy support
-


### PR DESCRIPTION
I got a ec42 policy by default - and probetests pass on master.

Drive-by update to .gitignore for .vagrant droppings.
