### PR TITLE
upgrade setuptools via pip

### DIFF
--- a/roles/pre_config/tasks/main.yml
+++ b/roles/pre_config/tasks/main.yml
@@ -50,3 +50,4 @@
       - Paste
       - pyudev
       - pip
+      - setuptools

--- a/roles/pre_config/tasks/main.yml
+++ b/roles/pre_config/tasks/main.yml
@@ -22,9 +22,8 @@
       - git-core
       - libffi-devel
       - xinetd
-      - python-setuptools
       - python-devel
-      - python-simplejson 
+      - python-simplejson
       - pyxattr
       - python-eventlet
       - python-greenlet


### PR DESCRIPTION
setuptools version provided by centos package is lower than 17.1 as explained in [Compatibility Notes](http://docs.openstack.org/developer/pbr/compatibility.html#evaluate-marker).

got the following error:
`TASK: [swift | build a development installation of swift] ********************* 
failed: [server0] => {"changed": true, "cmd": ["python", "setup.py", "develop"], "delta": "0:00:01.355440", "end": "2016-04-29 13:58:29.649145", "rc": 1, "start": "2016-04-29 13:58:28.293705", "warnings": []}
stderr: Marker evaluation failed, see the following error.  For more information see: http://docs.openstack.org/developer/pbr/compatibility.html#evaluate-marker
ERROR:root:Error parsing
`
