### PR TITLE
Disable EPEL and use only RDO repos

### DIFF
--- a/roles/pre_config/tasks/main.yml
+++ b/roles/pre_config/tasks/main.yml
@@ -5,8 +5,12 @@
 #  - name: create rc.local from template
 #    template: src=config.j2 dest=/home/{{ username }}/.ssh/config owner={{ username}} group={{ group }} mode=0600
 
-  - name: install epel-release
-    yum: name=epel-release state=present
+#  - name: install epel-release
+#    yum: name=epel-release state=present
+#    when: ansible_distribution in ['RedHat', 'CentOS']
+
+  - name: install centos-release-openstack-queens
+    yum: name=centos-release-openstack-queens state=present
     when: ansible_distribution in ['RedHat', 'CentOS']
 
   - name: installing dependencies


### PR DESCRIPTION
While installing with this playbook i encountered errors when installing
test-requirements with pip. The error was related to pyparsing that had to
be updated to at least 2.2.0 for satisfying the dependencies of
python-keystoneclient (oslo.utils depends on pyparsing).
Centos provides 1.5.x version of pyparsing, instead RDO repos provides
an updated version.

Additionally using RDO repos and EPEL is discouraged, due to updates in
EPEL breaking backwards compatibility.
See: https://docs.openstack.org/ocata/install-guide-rdo/environment-packages.html#prerequisites