### PR TITLE
Changed test on libec_rpm variable

### DIFF
--- a/roles/liberasurecode/tasks/install_package.yml
+++ b/roles/liberasurecode/tasks/install_package.yml
@@ -7,7 +7,7 @@
   with_items:
     - liberasurecode
     - python-pyeclib
-  when: not libec_rpm
+  when: libec_rpm is not defined or not libec_rpm
 
 - name: install specific libec rpm
   package: name={{ libec_rpm }}

--- a/roles/liberasurecode/tasks/install_package.yml
+++ b/roles/liberasurecode/tasks/install_package.yml
@@ -1,6 +1,6 @@
 - name: install cloud sig
   package: name=centos-release-openstack-queens state=present
-  when: (ansible_distribution in ['RedHat', 'CentOS'] and not libec_rpm)
+  when: (ansible_distribution in ['RedHat', 'CentOS'] and libec_rpm is defined)
 
 - name: installing dependencies
   package: name={{ item }} state=present
@@ -11,8 +11,8 @@
 
 - name: install specific libec rpm
   package: name={{ libec_rpm }}
-  when: libec_rpm
+  when: libec_rpm is defined and libec_rpm
 
 - name: install specific pyeclib rpm
   package: name={{ pyeclib_rpm }}
-  when: pyeclib_rpm
+  when: pyeclib_rpm is defined and pyeclib_rpm


### PR DESCRIPTION
By default on global_vars libec_rpm and pyeclib_rpm are commented out
This leads a failure in the execution because variables are undefined
and testing their value is not possible.
Now libec_rpm is tested for existence before testing if empty or not.